### PR TITLE
add e2e test rbac

### DIFF
--- a/samples/e2e_test_rbac/create_e2e-test_kubeconfig.sh
+++ b/samples/e2e_test_rbac/create_e2e-test_kubeconfig.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+set -x
+# 首先需要把设置好读写证书，如 export KUBECONFIG=kube-write.config
+
+kubectl apply -f service_account.yaml
+kubectl apply -f service_account_cluster_role.yaml
+kubectl apply -f service_account_cluster_role_binding.yaml
+kubectl apply -f secret.yaml
+
+# 请根据您的环境和需求进行调整
+NAMESPACE="default"        # 指定命名空间
+SERVICE_ACCOUNT_NAME="e2e-test" # 替换为您的 ServiceAccount 名称
+SECRET_NAME="$SERVICE_ACCOUNT_NAME-secret"
+
+# 获取 Secret 的 CA 证书和 Token
+CA_CERT=$(kubectl get secret $SECRET_NAME -n $NAMESPACE -o=jsonpath='{.data.ca\.crt}' | base64 --decode)
+TOKEN=$(kubectl get secret $SECRET_NAME -n $NAMESPACE -o=jsonpath='{.data.token}' | base64 --decode)
+
+# 获取集群信息
+CLUSTER_NAME=$(kubectl config current-context) # 获取当前上下文名称
+CLUSTER_ENDPOINT=$(kubectl cluster-info | grep 'Kubernetes control plane' | awk '/https/ {print $NF}')
+
+# 生成 kubeconfig 文件
+KUBECONFIG_FILE="kubeconfig-${SERVICE_ACCOUNT_NAME}.yaml"
+
+cat <<EOF > $KUBECONFIG_FILE
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: $(echo "$CA_CERT" | base64)
+    server: $CLUSTER_ENDPOINT
+  name: $CLUSTER_NAME
+contexts:
+- context:
+    cluster: $CLUSTER_NAME
+    user: $SERVICE_ACCOUNT_NAME
+  name: ${SERVICE_ACCOUNT_NAME}-context
+current-context: ${SERVICE_ACCOUNT_NAME}-context
+users:
+- name: $SERVICE_ACCOUNT_NAME
+  user:
+    token: $TOKEN
+EOF
+
+echo "kubeconfig 文件已生成: $KUBECONFIG_FILE"

--- a/samples/e2e_test_rbac/secret.yaml
+++ b/samples/e2e_test_rbac/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: e2e-test-secret
+  annotations:
+    kubernetes.io/service-account.name: e2e-test
+type: kubernetes.io/service-account-token

--- a/samples/e2e_test_rbac/service_account.yaml
+++ b/samples/e2e_test_rbac/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: e2e-test

--- a/samples/e2e_test_rbac/service_account_cluster_role.yaml
+++ b/samples/e2e_test_rbac/service_account_cluster_role.yaml
@@ -1,0 +1,8 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: e2e-test-role
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["pods" , "pods/status", "pods/spec","nodes", "nodes/status" , "deployments", "daemonSets", "events"]
+    verbs: ["get", "watch", "list"]

--- a/samples/e2e_test_rbac/service_account_cluster_role_binding.yaml
+++ b/samples/e2e_test_rbac/service_account_cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-test-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: e2e-test-role
+subjects:
+  - kind: ServiceAccount
+    name: e2e-test
+    namespace: default


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a ServiceAccount to manage permissions for pods in Kubernetes.
	- Added a ClusterRole with specific permissions for various resources in the cluster.
	- Implemented a ClusterRoleBinding to associate the ServiceAccount with the new ClusterRole for enhanced role-based access control during end-to-end testing.
	- Added a Secret to hold a token for the ServiceAccount.
	- Created a script to automate the generation of a kubeconfig file for the ServiceAccount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->